### PR TITLE
Overhaul the initial version of the OpenHeroSelect script

### DIFF
--- a/Instructions.txt
+++ b/Instructions.txt
@@ -1,21 +1,21 @@
-OpenHeroSelect (OPH) works mostly like the original HeroSelect where you would modify a herostat.cfg file and then select the Default option.
+OpenHeroSelect (OHS) works mostly like the original HeroSelect where you would modify a herostat.cfg file and then select the Default option.
 Below is information on required files and usage:
 
 Running OpenHeroSelect:
-	- To run OPH you must must have the OpenHeroSelect.exe or OpenHeroSelect.py files, the menulocation.cfg file, a herostat.cfg file and the xmlb-compile.exe file in a same folder.
+	- To run OHS you must must have the OpenHeroSelect.exe or OpenHeroSelect.py files, the menulocation.cfg file, a herostat.cfg file and the xmlb-compile.exe file in a same folder.
 	- Make sure the required files are there, that the herostat.cfg file is set up properly and that the menulocation.cfg file matches the amout of characters you want (more information on this below).
-	- Once everything is in place, OPH can be run in two different ways:
+	- Once everything is in place, OHS can be run in two different ways:
 		1) By executing its .exe file (hands-off execution).
 		2) By executing its .exe or .py files from a command-line interface (more customizable).
 	
-	1) Running OPH from its Executable:
+	1) Running OHS from its Executable:
 	- To prevent issues with Windows 10 redirecting writes to the wrong location, make sure you right-click OpenHeroSelect.exe and run it as Administrator instead of just double-clicking the file.
 	- OpenHeroSelect.exe will read the herostat.cfg file in its same folder, attempt to create the compiled herostat files for the game and place them in the data folder that was specified in the herostat.cfg file.
 	- If everything works out well, you will be prompted by a success message and you should see your chosen heroes in-game.
 	- If any issues arise you will be notified by a failure message and you might need to do some troubleshooting through the command-line methods.
 	
-	2) Running OPH from the Command-Line:
-	- To run OPH from the command-line in Windows, open a shell such as CMD or PowerShell at the directory with the OPH files.
+	2) Running OHS from the Command-Line:
+	- To run OHS from the command-line in Windows, open a shell such as CMD or PowerShell at the directory with the OHS files.
 	- From there, execute the .exe file following by optional flags you may want to to achieve different results.
 	- Alternatively, you can also execute the .py files if you have Python in your system.
 	
@@ -27,16 +27,16 @@ Running OpenHeroSelect:
 			-v, --verbose: Write extensive process information, will show warnings, print error messages & hints on possible solutions when available.
 		
 		Examples:
-			- ".\OpenHeroSelect.exe -h" (without the quotes) - this will run the .exe OPH file and display the help menu.
-			- ".\OpenHeroSelect.exe -v -l" (without the quotes) - this will run the .exe OPH file in verbose mode, and list the character positions.
-			- "python .\OpenHeroSelect.py -h" (without the quotes) - this will run the Python OPH file and display the help menu.
-			- "python .\OpenHeroSelect.py -v -d" (without the quotes) - this will run the Python OPH file and stop after generating the "XML" file.
+			- ".\OpenHeroSelect.exe -h" (without the quotes) - this will run the .exe OHS file and display the help menu.
+			- ".\OpenHeroSelect.exe -v -l" (without the quotes) - this will run the .exe OHS file in verbose mode, and list the character positions.
+			- "python .\OpenHeroSelect.py -h" (without the quotes) - this will run the Python OHS file and display the help menu.
+			- "python .\OpenHeroSelect.py -v -d" (without the quotes) - this will run the Python OHS file and stop after generating the "XML" file.
 	
 	
 Making a herostat.cfg:
-	- The herostat.cfg file is the place were you tell OPH the location of your game data directory, list the characters to be loaded and define their respective herostats.
+	- The herostat.cfg file is the place were you tell OHS the location of your game data directory, list the characters to be loaded and define their respective herostats.
 	- An example herostat.cfg file is provided which can be used as a template.
-	- Lines that start with a "#" sign are comments - they are ignored by OPH and you can use to write down notes or other remarks.
+	- Lines that start with a "#" sign are comments - they are ignored by OHS and you can use to write down notes or other remarks.
 	- The first non-commented line must be a path to your MUA install's data folder. Use double backslashes instead of single ones and make sure there's a double backslash at the end of the path, for example "C:\\blah\\MUA\\data\\" (without the quotes).
 	- The following sequence of non-commented lines will be treated as the list of the characters you want. The order of this characters in the selectio menu will be determined by the menulocations.cfg file (included files work from left to right).
 	- After the character namelist there needs to be a line with "-----" (without quotes). This line indicates where the namelist section ends and the stat definition section begins.
@@ -45,9 +45,9 @@ Making a herostat.cfg:
 	- Feel free to have as many names in the namelist and stats in the stat list as you want, the program will limit itself to the first 27/38/50/etc. depending on menulocations.cfg.
 	
 	Notes:
-	- Spaces between stat entries and indentation consistency don't really matter - OPH makes use of regular expressions and other techniques to allow for some leeway.
-	- If you want to rearrange the characters, you can either reorder the namelist and it'll automatically take care of it, or manually define their position and use OPH with the keep flag.
-	- Defaultman is a placeholder entry - in v2.0 of OPH you can either include it in the namelist/stat entries or not - the program will automatically detect it and include it in the "XML" file anyways.
+	- Spaces between stat entries and indentation consistency don't really matter - OHS makes use of regular expressions and other techniques to allow for some leeway.
+	- If you want to rearrange the characters, you can either reorder the namelist and it'll automatically take care of it, or manually define their position and use OHS with the keep flag.
+	- Defaultman is a placeholder entry - in v2.0 of OHS you can either include it in the namelist/stat entries or not - the program will automatically detect it and include it in the "XML" file anyways.
 	- If any issues arise, run the program in verbose/debug mode to track the issues down, or check the forums.
 
 Setting up menulocations.cfg:
@@ -60,7 +60,7 @@ Setting up menulocations.cfg:
 	- If you want 50 heroes, then either copy the contents of the "menulocations - 50..." file into menulocations.cfg or swap their names.
 	- There is typically no need to modify the contents of the menulocations files themselves, unless you want to rearrange the positions of the characters that way.
 	- You can add comments, they must be on their own line and the line must start with the '#' character.
-	- A great way of visualizing what is going on is to run OPH with the list flag.
+	- A great way of visualizing what is going on is to run OHS with the list flag.
 	
 Troubleshooting:
 	- The xmlb-compile.exe file is a third-party file written by NBA2KSTUFF which does the actual compiling from an intermediate "XML" format into the binary files for the game.

--- a/Instructions.txt
+++ b/Instructions.txt
@@ -1,37 +1,75 @@
-Mostly works like the original heroselect with the method where you would modify its herostat.cfg and then select the Default option.
+OpenHeroSelect (OPH) works mostly like the original HeroSelect where you would modify a herostat.cfg file and then select the Default option.
 Below is information on required files and usage:
 
 Running OpenHeroSelect:
-	- Make sure the required files are there and herostat.cfg is set up properly.
-	- Run OpenHeroSelect.exe and it should automatically create your herostat files and place them in the data folder as defined in herostat.cfg.
-	- To prevent issues with Windows 10 redirecting writes to the wrong location, make sure you right-click OpenHeroSelect.exe and run it as Administrator when you run it, instead of just double-clicking the file.
-	- If you run it through the command line, there are flags to note:
-		-d,--debug: Writes a herostat.xml file to the same directory, then stops instead of creating the xmlb files
-		-h,--help: print help text
+	- To run OPH you must must have the OpenHeroSelect.exe or OpenHeroSelect.py files, the menulocation.cfg file, a herostat.cfg file and the xmlb-compile.exe file in a same folder.
+	- Make sure the required files are there, that the herostat.cfg file is set up properly and that the menulocation.cfg file matches the amout of characters you want (more information on this below).
+	- Once everything is in place, OPH can be run in two different ways:
+		1) By executing its .exe file (hands-off execution).
+		2) By executing its .exe or .py files from a command-line interface (more customizable).
+	
+	1) Running OPH from its Executable:
+	- To prevent issues with Windows 10 redirecting writes to the wrong location, make sure you right-click OpenHeroSelect.exe and run it as Administrator instead of just double-clicking the file.
+	- OpenHeroSelect.exe will read the herostat.cfg file in its same folder, attempt to create the compiled herostat files for the game and place them in the data folder that was specified in the herostat.cfg file.
+	- If everything works out well, you will be prompted by a success message and you should see your chosen heroes in-game.
+	- If any issues arise you will be notified by a failure message and you might need to do some troubleshooting through the command-line methods.
+	
+	2) Running OPH from the Command-Line:
+	- To run OPH from the command-line in Windows, open a shell such as CMD or PowerShell at the directory with the OPH files.
+	- From there, execute the .exe file following by optional flags you may want to to achieve different results.
+	- Alternatively, you can also execute the .py files if you have Python in your system.
+	
+		Flags:
+			-h, --help: Display a help text with these same argument definitions.
+			-d, --debug: Stop after parsing the herostat.cfg file and writing the intermediate "xml" file. It will not compile or replace gamefiles.
+			-k, --keep: Keeps the menupositions indicated in the herostat.cfg file for those who prefer to manually organize their characters.
+			-l, --list: Show the list of characters that were loaded from the herostat.cfg file and their to-be positions in the hero select menu.
+			-v, --verbose: Write extensive process information, will show warnings, print error messages & hints on possible solutions when available.
+		
+		Examples:
+			- ".\OpenHeroSelect.exe -h" (without the quotes) - this will run the .exe OPH file and display the help menu.
+			- ".\OpenHeroSelect.exe -v -l" (without the quotes) - this will run the .exe OPH file in verbose mode, and list the character positions.
+			- "python .\OpenHeroSelect.py -h" (without the quotes) - this will run the Python OPH file and display the help menu.
+			- "python .\OpenHeroSelect.py -v -d" (without the quotes) - this will run the Python OPH file and stop after generating the "XML" file.
+	
+	
+Making a herostat.cfg:
+	- The herostat.cfg file is the place were you tell OPH the location of your game data directory, list the characters to be loaded and define their respective herostats.
+	- An example herostat.cfg file is provided which can be used as a template.
+	- Lines that start with a "#" sign are comments - they are ignored by OPH and you can use to write down notes or other remarks.
+	- The first non-commented line must be a path to your MUA install's data folder. Use double backslashes instead of single ones and make sure there's a double backslash at the end of the path, for example "C:\\blah\\MUA\\data\\" (without the quotes).
+	- The following sequence of non-commented lines will be treated as the list of the characters you want. The order of this characters in the selectio menu will be determined by the menulocations.cfg file (included files work from left to right).
+	- After the character namelist there needs to be a line with "-----" (without quotes). This line indicates where the namelist section ends and the stat definition section begins.
+	- For each name on the namelist there must be a matching stat entry. These entries consist on the character name followed by a stat definition entry (see the template for examples).
+	- Herostat entries for modded characters can normally be found within their compressed packages (sometimes in the at the root, sometimes within the data folder) or in the forums.
+	- Feel free to have as many names in the namelist and stats in the stat list as you want, the program will limit itself to the first 27/38/50/etc. depending on menulocations.cfg.
+	
+	Notes:
+	- Spaces between stat entries and indentation consistency don't really matter - OPH makes use of regular expressions and other techniques to allow for some leeway.
+	- If you want to rearrange the characters, you can either reorder the namelist and it'll automatically take care of it, or manually define their position and use OPH with the keep flag.
+	- Defaultman is a placeholder entry - in v2.0 of OPH you can either include it in the namelist/stat entries or not - the program will automatically detect it and include it in the "XML" file anyways.
+	- If any issues arise, run the program in verbose/debug mode to track the issues down, or check the forums.
 
-herostat.cfg:
-	- First line must be path to MUA install's data folder (you cannot put a comment before the path). Use double backslashes instead of single ones and make sure there's a double backslash at the end of the path, for example "C:\\blah\\MUA\\data\\" but no quotes
-	-Starting at second line, list the hero you want. Order in the menu is determined by the menulocations.cfg file (included files work from left to right).
-	- Needs to have "-----" without quotes on its own line between character names list section and stat definitions section. This tells the program to stop looking at names and to look at stats instead.
-	- Each stat needs to be name followed by the stat definition.
-	- Each name in the list must have a corresponding stat definition.
-	- Feel free to have as many names in the name list and stats in the stat list as you like, the program will limit itself to the first 27 (or 28, 33, etc. depending on menulocations.cfg), just reorder the names list and it'll automatically take care of it.
-	- You can add comments, they must be on their own line and the line must start with the '#' character. The first line of the file can't be a comment, it has to be the path.
-	- Use the included herostat.cfg as a template, it should be pretty easy to figure out.
-	
-menulocations.cfg:
-	- Typically no need to modify the menulocations files themselves.
+Setting up menulocations.cfg:
+	- The file menulocations.cfg is meant for you to manually overwrite with whichever of the other specific menulocation files you want.
+	- The "menulocations - #.cfg" files contain lists lists of positions matching the number in their name.
+	- Files match characters in the namelist from left to right in the selection menu rows, so the first name in the herostat.cfg will be on the left for example.
 	- Pick the version with the number of characters you want and copy it with the name menulocations.cfg (the included default one is for the standard 27 characters, but you can replace it with the expanded roster hack versions if you use those).
-	- Default files are set up to work from left to right, so the first name in the herostat.cfg will be on the left for example.
-	- You can add comments, they must be on their own line and the line must start with the '#' character.
 	
-other requirements:
-	- xmlb-compile.exe must be in the folder with OpenHeroSelect.exe as well as the .cfg files
-	- If you run into errors, delete everything except OpenHeroSelect.exe, xmlb-compile.exe, and the .cfg files, and try again.
-	- If that doesn't work, try running the app as Administrator (right-click on OpenHeroSelect, Run as administrator)
+	Example:
+	- If you want 50 heroes, then either copy the contents of the "menulocations - 50..." file into menulocations.cfg or swap their names.
+	- There is typically no need to modify the contents of the menulocations files themselves, unless you want to rearrange the positions of the characters that way.
+	- You can add comments, they must be on their own line and the line must start with the '#' character.
+	- A great way of visualizing what is going on is to run OPH with the list flag.
+	
+Troubleshooting:
+	- The xmlb-compile.exe file is a third-party file written by NBA2KSTUFF which does the actual compiling from an intermediate "XML" format into the binary files for the game.
+	- If you run into errors, try to run the program in the verbose mode first - it provides error propagation as well as hints on how to solve some of the most common ones.
+	- If things go horribly wrong, delete everything except OpenHeroSelect.exe, xmlb-compile.exe, and the .cfg files, and try running the program again.
+	- If that doesn't work, try running the app/command-line as Administrator (right-click on OpenHeroSelect, Run as administrator)
 	
 Converting the original HeroSelect's herostat.cfg file into the OpenHeroSelect version:
-	- data folder path is exactly the same.
+	- Data folder path is exactly the same.
 	- Name list is slightly different.
 		- defaultman doesn't have to be at the beginning, OpenHeroSelect takes all the names from the first one down (extra names are just ignored like the old HeroSelect, so you can leave more names in after the ones that will be included if you want).
 		- endofffile should be removed, OpenHeroSelect takes care of it.

--- a/OpenHeroSelect.py
+++ b/OpenHeroSelect.py
@@ -1,160 +1,83 @@
-import re, subprocess, os, getopt, sys
+# General system imports
+import os, subprocess, sys, time
+# Command-line argument parser
+import getopt
+# Regular expressions
+import re
+# Color for command line messages
+import colorama
+from colorama import Fore, Style
 
-# Main function
-def main():
-    # get desired number of characters from user
-    menuLocations = getMenuLocations()
-    # tell user to wait
-    print("Generating herostat with " + str(len(menuLocations)) + " characters, please wait...")
-    # create data
-    dataDict = readHerostatCfg()
-    # build herostat.xml
-    with open(herostatName + ".xml", "w") as xml:
-        xml.write(firstLines)
-        # for each character up to the number of menulocations
-        for character, menuLocation in zip(dataDict[namesKey], menuLocations):
-            if character not in dataDict[statsKey]:
-                print("ERROR! Missing stats entry for " + character + "! Aborting!")
-                return
-            # replace the menulocation placeholder with a value
-            for i, line in enumerate(dataDict[statsKey][character]):
-                if "[menulocation]" in line:
-                    dataDict[statsKey][character][i] = line.replace("[menulocation]", menuLocation)
-            xml.writelines(dataDict[statsKey][character])
-            xml.write("\n")
-        xml.write(endLines)
-    # if debug mode, stop here
-    if flagDebug:
-        print("generated herostat.xml")
-        sys.exit(0)
-    # compile and move herostat binary files
-    generateHerostatBinary(dataDict[dataPathKey])
-    # delete herostat.xml
-    os.remove(herostatName + ".xml")
-    # tell user we're done
-    print("Done! Go ahead and launch MUA!")
+# Argument Variables & Help Texts ============================================
+unixOptions = "dhklv" # Concatenation of modes
+gnuOptions = ["debug","help", "keep", "list","verbose"] # List of modes
 
-# Ask user for desired number of characters
-def getMenuLocations():
-    menuLocations = []
-    with open("menulocations.cfg", "r") as cfg:
-        for line in cfg:
-            if line.strip():
-                if not line.strip().startswith('#'):
-                    menuLocations.append(line.strip())
-        return menuLocations
+flagDebug = False   # If true, stop after writing XML file instead of generating xmlb
+flagKeep = False    # If true, keep the menupositions from the herostat file
+flagList = True    # If true, will print a list showing the rooster and heroes to be loaded
+flagVerbose = False # If true, write process information and hints during execution
 
-# Read herostat.cfg file
-def readHerostatCfg():
-    # open herostat.cfg in read-only mode
-    with open("herostat.cfg", "r") as cfg:
-        # first line becomes path to data directory in MUA
-        dataPath = cfg.readline().strip()
+helpText =  ["USAGE:\n",
+            "-h, --help: Display this help text.\n",
+            "-d, --debug: Stop after writing the xml file. Will not compile or replace gamefiles.\n",
+            "-k, --keep: Keeps the menupositions indicated in the herostat.cfg file.\n",
+            "-l, --list: Show the list of characters loaded and their positions in the hero select menu.\n",
+            "-v, --verbose: Write process information, warnings, errors & hints.\n",
+            "\nFor more help visit the forums!\n"]
 
-        # read all the names of the characters at the top of the herostat.cfg
-        # read until the "-----" (divider between names and stats) is encountered
-        names = []
-        while True:
-            line = cfg.readline()
-            if line.strip() == fileDivider:
-                break
-            elif not line.strip():
-                continue
-            else:
-                names.append(line.strip())
-
-        # read all the stats until the end of the file
-        stats = {}
-        singleStat = []
-        singleStatName = ""
-        # this var is used when encountering braces to make sure we don't accidentally close the stat too early (0 means we're on the stat definition level)
-        braceLevel = 0
-        # this var is to make sure we're inside a stat
-        inStat = False
-        while True:
-            line = cfg.readline()
-            # empty line means end of file, finished
-            if not line:
-                break
-            # blank line, useless
-            if not line.strip():
-                continue
-            # comment line, skip
-            if line.strip().startswith('#'):
-                continue
-            # encountering a closing brace that isn't ending the stat definition
-            if '}' in line and inStat and braceLevel > 0:
-                singleStat.append(line)
-                braceLevel -= 1
-            # encountering an opening brace that isn't starting the stat definition
-            elif '{' in line and inStat:
-                singleStat.append(line)
-                braceLevel += 1
-            # character's name found, start reading into a stat
-            elif line.strip() in names:
-                singleStatName = line.strip()
-            # beginning line of a stat definition found
-            elif re.sub(r'\s+', ' ', line).strip() == statBegin.strip():
-                singleStat.append(statBegin)
-                inStat = True
-                braceLevel = 0
-            # ending line of a stat definition found, add to stats, then set the singleStatName (current character) to blank so we don't override the existing one
-            elif line.strip() == statEnd.strip() and inStat and braceLevel == 0:
-                singleStat.append(statEnd)
-                stats[singleStatName] = singleStat[:] # copy so the stats version doesn't get modified when the temp one is reset
-                singleStat = []
-                singleStatName = ""
-                inStat = False
-            elif "menulocation" in line:
-                singleStat.append(menuLocationBegin + "[menulocation]" + " ;\n")
-            # not a special line, should just be something inside a stat definition
-            elif inStat:
-                singleStat.append(line)
-
-        # put everything into a dictionary to return
-        dataDict = {
-            dataPathKey: dataPath,
-            namesKey: names,
-            statsKey: stats
+knownXMLBErrors = {
+            "Data folder not found": "The path to the game data folder in herostat.cfg could not be located.",
+            "XML not found": "Something went wrong during the generation of the file (i.e. no write permissions) or the file was removed mid-process.",
+            "parm 1 or { [ ( expected": "A capricious error - can sometimes be solved by removing random empty spaces or characters from the herostat.cfg file.",
+            "Blank": "A blank error message can occur when having a race condition with xmlb-compiler (try rerunning OPH)"
         }
-        return dataDict
 
-# Generate each herostat binary file and move it to its proper location
-def generateHerostatBinary(path):
-    for ext in herostatBinaryExts:
-        herostatFilename = herostatName + ext
-        subprocess.run(["xmlb-compile.exe", "-s", "herostat.xml", herostatFilename])    
-        os.replace(herostatFilename, path + herostatFilename)
-    return
+# Files and Binaries =========================================================
 
-# debug flag (if true, stop after writing XML file instead of generating xmlb)
-flagDebug = False
-
-# help text
-helpText = "Usage:\n-d,--debug: stop after writing the xml file instead of making and moving the xmlb file\n-h,--help: display this help text\n"
-
-# command args
-unixOptions = "dh"
-gnuOptions = ["debug","help"]
-
-# herostat binary filename and extensions
+dataPath = None
 herostatName = "herostat"
 herostatBinaryExts = [".xmlb", ".engb", ".itab", ".freb", ".gerb"]
 
-# dataDict return keys
-dataPathKey = "dataPath"
+# Hero Menu ==================================================================
+heroPositions50 = [
+    "    54  51  48  01  45  46  05  16  17  40  19  42  11  50  58  61    ",
+    "    53  37  25  47  03  04  14  06  07  08  22  10  43  49  57  60    ",
+    "55  52  35  44  02  13  21  15  18  23  24  09  41  20  12  56  59  62"
+]
+
+heroPositions36 = [
+    "            48  01  45  46  05  16  17  40  19  42  11  50",
+    "            25  47  03  04  14  06  07  08  22  10  43  49",
+    "            44  02  13  21  15  18  23  24  09  41  20  12"
+]
+
+heroPositions27 = [
+    "                 25  03  04  14  06  23  24  09  12",
+    "                 01  13  21  15  16  17  26  19  11",
+    "                 02  96  05  18  07  08  22  10  20"
+]
+
+roosterPositions = {
+    "27": heroPositions27,
+    "36": heroPositions36,
+    "50": heroPositions50
+}
+
+# Hero Stat Dictionary Keys ==================================================
+
 namesKey = "names"
 statsKey = "stats"
 
-# divider between characters' names and characters' stats
-fileDivider = "-----"
+# String Definitions for Parsing herostat.cfg ================================
 
-# key parts of the herostat.xml
-menuLocationBegin = "   menulocation = "
-statBegin = "   stats {\n"
-statEnd = "   }\n"
-firstLines = "XMLB characters {\n\
-   stats {\n\
+fileDivider = "-----"
+menuLocationBegin = "menulocation = "
+
+# String Definitions for the herostat.xml file ===============================
+headerLine = "XMLB characters {\n"
+statBegin = "stats {\n"
+statEnd = "}"
+defaultmanEntry = "stats {\n\
    autospend = support_heavy ;\n\
    body = 1 ;\n\
    characteranims = 00_testguy ;\n\
@@ -170,40 +93,333 @@ firstLines = "XMLB characters {\n\
       level = 1 ;\n\
       name = fightstyle_default ;\n\
       }\n\
-   }\n\
-\n\
-   stats {\n\
+   }\n\n"
+myTeamEntry = "stats {\n\
    autospend = support ;\n\
    isteam = true ;\n\
    name = team_character ;\n\
    skin = 0002 ;\n\
    xpexempt = true ;\n\
    }\n\n"
-endLines = "}"
+indentation = "   "
+endLine = "}"
 
-if __name__ == '__main__':
-    # get command line args
+# Helper methods =============================================================
+
+# Print a corny header for flair, console separation and link to the forum
+def printHeader():
+    title1 = "█▀█ █▀█ █▀▀ █▄ █   █ █ █▀▀ █▀█ █▀█   █▀ █▀▀ █   █▀▀ █▀▀ ▀█▀"
+    title2 = "█▄█ █▀▀ ██▄ █ ▀█   █▀█ ██▄ █▀▄ █▄█   ▄█ ██▄ █▄▄ ██▄ █▄▄  █ (v2)"
+    page = "https://marvelmods.com/forum/"
+    print(f"{Fore.GREEN}{title1}\n{title2}")
+    print(f"{Fore.RED}\n\t\t{page}\n")
+
+# Exit function wrapper
+def exit(status):
+    # Require keypress to avoid fast-closing consoles
+    input('\n> Press enter to exit <')
+    sys.exit(status)
+
+# Print green colored sucess messages
+printSuccess = lambda text: print(f"{Fore.GREEN}{text}")
+# Print yellow colored warning messages
+printWarning = lambda text: print(f"{Fore.YELLOW + Style.BRIGHT }! WARNING: {text}")
+# Print red colored error messages
+printError = lambda text: print(f"{Fore.RED}! ERROR: {text}")
+
+# Core Function Definitions =================================================
+
+# Read menulocations for the desired number of characters
+def getMenuLocations():
+    menuLocations = []
+    with open("menulocations.cfg", "r") as cfg:
+        for line in cfg:
+            line = line.strip() # Clean spaces
+            if line and not line.startswith('#'):   # If not empty or commented
+                menuLocations.append(line)    
+    return menuLocations
+
+# Read herostat.cfg file
+def readHerostatCfg(maxCharacters):
+    # Open herostat.cfg in read-only mode
+    with open("herostat.cfg", "r") as cfg:
+        # Skip over initial comment lines if any until finding datapath
+        while True:
+            line = cfg.readline()
+            if not line.startswith('#'):
+                # First non-commented line becomes path to data directory in MUA
+                global dataPath
+                dataPath = line.strip()
+                break
+
+        if flagVerbose:
+            # Inform the game datafolder that was found
+            print(f"> Game data folder at: {dataPath}")
+
+        # Read the namelist at the top of the herostat.cfg
+        # Finish reading when the "-----" (divider between names and stats) is encountered
+        # Ignore entries after the maximum number of characters has been reached
+        names = []
+        while True:
+            line = cfg.readline().strip()
+            if line == fileDivider:
+                break
+            elif not line:
+                continue
+            elif line[:1] == '#':
+                continue
+            else:
+                # Ignore if character is repeated
+                if names.count(line) > 0:
+                    if flagVerbose: printWarning(f"Multiple entries for hero {line} in namelist")                
+                # Ignore if rooster is full and entry is not defaultman
+                elif len(names) == maxCharacters and line != "defaultman":
+                    if flagVerbose: printWarning(f"Character namelist surpass rooster capacity - {line} will be ignored")
+                # Add to list if all is good
+                else:
+                    names.append(line)                
+
+        # Read all the stats until the end of the file
+        stats = {}
+        singleStat = []
+        singleStatName = ""
+        # This var is used when encountering braces to make sure we don't accidentally close the stat too early (0 means we're on the stat definition level)
+        braceLevel = 0
+        # This var is to make sure we're inside a stat
+        inStat = False
+        while True:
+            line = cfg.readline()
+            # Empty line means end of file, finished
+            if not line:
+                break
+            # Blank line, useless
+            if not line.strip():
+                continue
+            # Comment line, skip
+            if line.strip().startswith('#'):
+                continue
+            # Encountering a closing brace that isn't ending the stat definition
+            if '}' in line and inStat and braceLevel > 0:
+                singleStat.append(line)
+                braceLevel -= 1
+            # Encountering an opening brace that isn't starting the stat definition
+            elif '{' in line and inStat:
+                singleStat.append(line)
+                braceLevel += 1
+            # Character's name found, start reading into a stat
+            elif line.strip() in names:
+                singleStatName = line.strip()
+            # Beginning line of a stat definition found
+            elif re.sub(r'\s+', ' ', line).strip() == statBegin.strip():
+                singleStat.append(f"{indentation}{statBegin}")
+                inStat = True
+                braceLevel = 0
+            # Ending line of a stat definition found, add to stats, then set the singleStatName (current character) to blank so we don't override the existing one
+            elif line.strip() == statEnd and inStat and braceLevel == 0:
+                singleStat.append(f"{indentation}{statEnd}")
+                stats[singleStatName] = singleStat[:] # copy so the stats version doesn't get modified when the temp one is reset
+                singleStat = []
+                singleStatName = ""
+                inStat = False
+            elif "menulocation" in line and not flagKeep:
+                singleStat.append(f"{indentation*2}{menuLocationBegin}[menulocation];\n")
+            # Not a special line, should just be something inside a stat definition
+            elif inStat:
+                singleStat.append(f"{indentation}{line}")
+
+        # Put everything into a dictionary to return
+        dataDict = {
+            namesKey: names,
+            statsKey: stats
+        }
+
+        printSuccess("> Herostat file succesfully loaded!")
+        return dataDict
+
+# Build the herostat.xml for the XMLB compiler
+def writeHerostatXML(dataDict, menuLocations):
+    # Note that despite the name (which was kept form the original version of OPH)
+    # the file generated is not really an XML file.
+    # This is simply a file that the xmlb-compile.exe program from NBA2KSTUFF accepts
+
+    with open(herostatName + ".xml", "w") as xml:
+        # Write the mandatory opening line
+        xml.write(headerLine)
+        # For each character up to the number of menulocations
+        for character, menuLocation in zip(dataDict[namesKey], menuLocations):
+            # Check that the stat entry is present
+            if character not in dataDict[statsKey]:
+                printError(f"Stats entry for hero: {character} could not be found")
+                if flagVerbose: print("> Likely Causes:\n\t - Missing stats entry \n\t - Missing name above stats entry \n\t - Name missmatch between list and stats entry (i.e. typos or caps)")
+                continue
+            
+            if flagKeep:
+                # Dome some validation on the menulocation entries for each hero
+                userLocations = []
+                for i, line in enumerate(dataDict[statsKey][character]):
+                    if "menulocation" in line:
+                        # Get the menulocation enty for the hero
+                        location = re.findall(r"\=(.*)\;", line)[0].strip()
+                        # Check if the entry is invalid, or has already been used
+                        if not location.isdigit():
+                            printError(f"Menu position entry for {character} is not numeric! Hero will not show up!")
+                        # Check for overlapping positions
+                        userLocations.append(location)
+                        if (userLocations.count(location) > 0):
+                            printWarning(f"Heroes with overlapping at menuposition {location} exist!")
+            else:
+                # Replace the menulocation placeholder with a values from the list
+                for i, line in enumerate(dataDict[statsKey][character]):
+                    if "[menulocation]" in line:
+                        dataDict[statsKey][character][i] = line.replace("[menulocation]", menuLocation)
+            
+            # Write the data onto the XML
+            xml.writelines(dataDict[statsKey][character])
+            xml.write("\n\n")
+
+        # Write the closing line
+        xml.write(endLine)
+        printSuccess("> XML file succesfully generated!")
+
+# Generate each herostat binary file and move it to its proper location
+def generateHerostatBinary(destination_path):
     try:
-        fullCmdArguments = sys.argv
-        argumentList = fullCmdArguments[1:]
-        arguments, values = getopt.getopt(argumentList, unixOptions, gnuOptions)
+        # Check that the xml file has been written
+        if not os.path.isfile("herostat.xml"):
+            raise Exception("Herostat XML file could not be found")
+
+        # Check that the destination path exists
+        if not os.path.exists(destination_path):
+            raise Exception("Game data folder could not be found")
+
+        # Attempt using xmlb-compile.exe to produce the final game files
+        if flagVerbose: printSuccess("> Compiling binary files with xmlb-compile")
+        for ext in herostatBinaryExts:
+            herostatFilename = herostatName + ext
+            result = subprocess.run(["xmlb-compile.exe", "-s", "herostat.xml", herostatFilename], capture_output=True)
+            time.sleep(0.2) # Give xmlb-compile.exe a buffer time to finish
+            
+            if flagVerbose: print(f"\t> {result.stderr.decode('UTF-8')[:-2]}")            
+            
+            # Check whether the compiler is succesful
+            if result.returncode == 1:
+                raise Exception(f"Message from xmlb-compile.exe: \"{Fore.RED + result.stdout.decode('UTF-8')[:-2] + Fore.WHITE}\"")
+            
+            # If all went well, replace game data files
+            os.replace(herostatFilename, destination_path + herostatFilename)
+
+    # Handle possible exceptions
+    except Exception as e:
+        printError("XMLB files could not be compiled!")
+        # Print complete error message and some known issues information
+        if flagVerbose:
+            printError(e)
+            print("\n> Known Errors:")
+            [print("\t", f"{error:<30s}", cause) for error, cause in knownXMLBErrors.items()]
+        return False
+
+    # Notify user if all went well
+    printSuccess("> Gamefiles succesfully updated!")
+    return True
+
+# Print a visual representation of the hero rooster
+def showRoosterAndList(dataDict, menuLocations, roosterSize):
+    # Print a map of the hero positions in the selection menu
+    menuMap = roosterPositions[str(roosterSize)]
+    print("\n============= Selection menu positions (from 50R images) =============\n")
+    print(*menuMap, sep="\n\n")
+    print("\n======================================================================\n")
+        
+    # Print a list of the parsed heroes along with their rows and positions
+    print("\n> Heroes parsed:")
+    for i, (character, menuLocation) in enumerate(zip(dataDict[namesKey], menuLocations), 1):
+        if character != "defaultman":
+            row = [row for row, rowPositions in enumerate(menuMap, 1) if menuLocation in rowPositions]
+            row = row[0] if len(row) > 0 else " "
+            print(f"\t{str(i):<3s} {character.capitalize():<24s} Row: {str(row):<10s} Position: {menuLocation}")
+        else:
+            print("\t-------------------------------------")
+            print(f"\t{'-':<3s} {character.capitalize():<20s}")
+
+    numHeroes = len(dataDict[namesKey])
+    if "defaultman" in dataDict[namesKey]: numHeroes = numHeroes - 1
+    if numHeroes < roosterSize:
+        printWarning(f"\nNot having a complete rooster of heroes can cause issues in savefiles ({numHeroes}/{roosterSize})\n")
+    else:
+        printSuccess(f"\n> Full rooster! ({numHeroes}/{roosterSize})")    
+
+# Main function
+def main():
+    # Get menu locations from menulocations file
+    menuLocations = getMenuLocations()
+    roosterSize = len(menuLocations)
+    # Tell user to wait
+    print("> Generating herostat for [" + str(roosterSize) + "] characters...")
+    # Generate hero data dictionary
+    dataDict = readHerostatCfg(roosterSize)
+    # Generate the "XML" file for the for the compiler
+    writeHerostatXML(dataDict, menuLocations)
+    
+    # Print rooster information and size check if in list mode
+    if flagList: showRoosterAndList(dataDict, menuLocations, roosterSize)
+    # If debug mode, stop here
+    if flagDebug:
+        printWarning("! Generated herostat.xml (game not modified)")
+        exit(0)
+
+    # Attempt compiling and updating the game herostat binary files
+    success = generateHerostatBinary(dataPath)
+    # Delete herostat.xml        
+    os.remove(herostatName + ".xml")
+
+    if success:
+        # Notify user we are done
+        printSuccess("\n> SUCCESS! Go ahead and launch MUA!")
+    else:
+        print(f"\n{Fore.RED}> FAILURE! Something went wrong - try verbose mode to see what's going on!")
+
+# Entry point for program
+if __name__ == '__main__':
+    # Initialize the command-line color module
+    colorama.init(autoreset=True, convert=True)
+    try:
+        # Parse command line args
+        args = sys.argv[1:]
+        arguments, values = getopt.getopt(args, unixOptions, gnuOptions)
+
+        # Set mode flags from args
         for currentArgument, currentValue in arguments:
             if currentArgument in ("-d", "--debug"):
                 print("DEBUG MODE")
                 flagDebug = True
             elif currentArgument in ("-h","--help"):
-                print(helpText)
-                sys.exit()
+                printHeader()
+                print(*helpText)
+                exit(0)
+            elif currentArgument in ("-k","--keep"):
+                print("KEEP LOCATION MODE")
+                flagKeep = True
+            elif currentArgument in ("-l","--list"):
+                print("LIST MODE")
+                flagList = True
+            elif currentArgument in ("-v","--verbose"):
+                print("VERBOSE MODE")
+                flagVerbose = True
+    
+    # Handle incorrect args
     except getopt.error as err:
-        # output error, and return with an error code
+        # Output error, and return with an error code
         print (str(err))
         print (helpText)
-        sys.exit(1)
+        exit(1)
 
-    # run main function
+    # Run main function
     try:
+        # Print a corny header and link to the forums
+        printHeader()
+        # Run the main method
         main()
+        exit(0)
     except Exception as e:
-        print(e)
-        print(helpText)
-        sys.exit(1)
+        print(f"! UNCAUGHT ERROR: {e}")
+        exit(1)


### PR DESCRIPTION
**General changes:**
- Reorganized code into sections for better readability
- Added extensive commenting (perhaps too much?) to hopefully help future contributors.
- Refactored functions for more modularity (and potentially a future GUI module).

**Extended the command-line interface:**
- Added a header for clear demarcation of execution and flair.
- Added versioning info & forum reference (hyperlink when in compatible shells such as PowerShell).
- Added color-coding for messages.

**Added new flag/operation modes:**
- Added verbose mode for clear notification of errors and reporting of warnings.
- Added list mode for visualization of the hero selection menus and hero rosters (currently supporting 27, 36 and 50 hero rosters).
- Added keep mode for allowing manual setting of hero positions without having to modify the menulocation.cfg file.

**Extended fault tolerance:**
- Extended the default help message with information on the new flags.
- Added a new "known problems" hint tool with information on common errors and solutions for users.
- Extended the xmlb-compile.exe wrapper to catch its return results and propagate errors to the user.
- Extended error-catching capability of the script.

**Miscellaneous code changes:**
- Cleaned up variable arrangement (i.e. datapath within herostat dictionary to a directly-accessible global).
- Cached certain functions which were repeatedly called (i.e. line.strip() in herostat parsing)
- Included requirement for key-press before closing the application.