### PR TITLE
faster code for xml2json

### DIFF
--- a/python_source/xml to json converter (BaconWizard17).py
+++ b/python_source/xml to json converter (BaconWizard17).py
@@ -2,94 +2,52 @@ import glob
 from pathlib import Path
 from argparse import ArgumentParser
 
-# this is used in the space_remover function so that needed spaces are kept
-special_chars = ';={}'
-
-# need a function to remove all spaces from lines. This makes working with the file easier
-def space_remover(old_line):
-    old_line = old_line.strip() # remove leading and trailing spaces (removes indent)
-    new_line = ''
-    i = 0
-    while i < len(old_line):
-        if old_line[i] == ' ':
-            if (old_line[i-1] in special_chars) or (old_line[i+1] in special_chars):
-                # if the character before or after the space is a special character,
-                # then the space can be removed.
-                # otherwise it is a string space, not whitespace
-                new_line = new_line # had to add this or else code would freak out
-            else:
-                # this is the string space case. Don't want to remove string spaces
-                new_line += old_line[i]
-        else:
-            # not a space, add as normal
-            new_line += old_line[i]
-        i += 1
-    return new_line
-
 # function to process new lines
-def main_converter(old_line):
-    new_line = '"'
-    for char in old_line:
-        if char == '=':
-            new_line += '": "'
-        elif char == ';':
-            new_line += '",'
-        elif char == '{':
-            new_line += '": {'
-        elif char == '\\':
-            new_line += '\\\\'
-        else:
-            new_line += char
+def convert_escape(old_line):
+    new_line = old_line.replace('\\', '\\\\')
+    new_line = new_line.replace('"', '\\"')
+    new_line = '"' + new_line
     return new_line
 
 def convert(file_name: Path):
     file_name = Path(file_name)
     # start by opening the file
     with open(file_name, mode='r') as file:
-        lines_original = []
-        # format B does not have blank lines, so they can be removed right away
+        lines_output = []
+        indent = 8
         for line in file:
+            # format B does not have blank lines, so they can be skipped
             if line.isspace() == False:
-                line_fixed = line.strip('\n')
-                lines_original.append(line_fixed)
 
-    # unless there is a header, then the indent starts at 8
-    indent = 8
+                # leading (indent) and trailing spaces can be removed
+                working_line = line.strip()
 
-    # these are the lines that will be written to the new file
-    lines_output = []
+                # begin performing conversion
+                if (working_line[0:4] == 'XMLB') and (working_line[-1] == '{'):
+                    # this is for the header
+                    lines_output.append('{')
+                    lines_output.append((' ' * 4) + '"' + working_line[4:-1].strip() + '": {')
+                elif working_line == '}':
+                    # this deals with lines that are closing brackets. Their indent is less than the previous line
+                    indent -= 4
+                    # previous line does not need to end in a comma
+                    lines_output[-1] = lines_output[-1].strip(',')
+                    lines_output.append((' ' * indent) + '},')
+                elif working_line[-1] == '{':
+                    # this deals with lines with open brackets. They increase the indent
+                    working_line = convert_escape(working_line)
+                    lines_output.append((' ' * indent) + working_line[:-1].strip() + '": {')
+                    indent += 4
+                else:
+                    working_line = convert_escape(working_line)
+                    working_line = working_line.replace(' = ', '": "', 1)
+                    if working_line[-1] == ';': working_line = working_line[:-1].strip()
+                    lines_output.append((' ' * indent) + working_line + '",')
 
-    # begin performing conversion
-    for line in lines_original:
-        working_line = space_remover(line)
-        if (working_line[0:4] == 'XMLB') and (working_line[-1] == '{'):
-            # this is for the header
-            lines_output.append('{')
-            lines_output.append((' ' * 4) + '"' + working_line[5:-1] + '"' + ': {')
-        elif working_line == '}':
-            # this deals with lines that are closing brackets. Their indent is less than the previous line
-            indent -= 4
-            lines_output.append((' ' * indent) + '},')
-        elif working_line[-1] == '{':
-            # this deals with lines with open brackets. They increase the indent
-            working_line = main_converter(working_line)
-            lines_output.append((' ' * indent) + working_line)
-            indent += 4
-        else:
-            working_line = main_converter(working_line)
-            output_line = (' ' * indent) + working_line
-            lines_output.append(output_line)
-
-    # if a full file is being converted, need to add an extra bracket because header is now 2 lines
+    # if a full file is being converted, need to add an extra bracket because header is now 2 lines (+ remove previous comma)
     if lines_output[0] == '{':
+        lines_output[-1] = lines_output[-1].strip(',')
         lines_output.append('}')
-
-    # if line i is a curly bracket, line i-1 does not need to end in a comma
-    i = 0
-    while i < len(lines_output):
-        if '}' in lines_output[i]:
-            lines_output[i-1] = lines_output[i-1].strip(',')
-        i += 1
 
     # this determines the output file name
     file_name_out = file_name.with_suffix('.json')


### PR DESCRIPTION
Removed the space_remover (instead strip is used 5x).
Changed character by character replacer (main_converter) to true replace function
main_converter, skipping empty lines, and comma remover all are now part of the "begin performing conversion" section. Part of it was duplicates.
(main_converter was only called twice, while each time it was mainly for the two, now three, still remaining replacements)
No longer replaces special characters in text strings (only looks at the first instance of " = " on each line).
Now adds the end of line characters, even if a semicolon is missing.