### PR TITLE
Fix bug with XML2; Combine multiparts for MUA

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -26,6 +26,8 @@ jobs:
     - name: Get latest tag
       id: previous-tag
       uses: WyriHaximus/github-action-get-previous-tag@v1.1.0
+      with:
+        fallback: 1.0.0
     - name: Get project version
       id: project-version
       uses: euberdeveloper/ga-project-version@v1.1.0

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,24 +13,22 @@ jobs:
       newtag: ${{ steps.check-result.outputs.newtag }}
     steps:
     - name: Wait on check
-      uses: lewagon/wait-on-check-action@v1.1.2
+      uses: lewagon/wait-on-check-action@v1.2.0
       with:
         ref: ${{ github.ref }}
         check-name: 'ESLint Check'
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         wait-interval: 30
     - name: Checkout code
-      uses: actions/checkout@v3.0.2
+      uses: actions/checkout@v3.1.0
       with:
         fetch-depth: 0
     - name: Get latest tag
       id: previous-tag
-      uses: WyriHaximus/github-action-get-previous-tag@v1.1.0
-      with:
-        fallback: 1.0.0
+      uses: WyriHaximus/github-action-get-previous-tag@v1.2.2
     - name: Get project version
       id: project-version
-      uses: euberdeveloper/ga-project-version@v1.1.0
+      uses: euberdeveloper/ga-project-version@v1.3.0
       with:
         package-manager: npm
     - name: Get versions
@@ -46,8 +44,8 @@ jobs:
         echo "Latest tag: ${{ env.oldtag_string }}"
         echo "Project version (prepended with v): ${{ env.newtag_string }}"
         echo "Generate new release: ${{ env.newbuild }}"
-        echo "::set-output name=newbuild::${{ env.newbuild }}"
-        echo "::set-output name=newtag::${{ env.newtag_string }}"
+        echo "newbuild=${{ env.newbuild }}" >> $GITHUB_OUTPUT
+        echo "newtag=${{ env.newtag_string }}" >> $GITHUB_OUTPUT
 
   build-release:
     name: Build and Release
@@ -56,13 +54,13 @@ jobs:
     if: ${{ needs.check-tag.outputs.newbuild == 'true' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3.0.2
+      uses: actions/checkout@v3.1.0
     - name: Setup Node.js
-      uses: actions/setup-node@v3.4.1
+      uses: actions/setup-node@v3.5.1
       with:
         node-version: '16.18'
     - name: Setup Python
-      uses: actions/setup-python@v4.2.0
+      uses: actions/setup-python@v4.3.0
       with:
         python-version: '3.10'
     - name: Install npm modules

--- a/js_source/openheroselect.js
+++ b/js_source/openheroselect.js
@@ -415,14 +415,14 @@ const main = async (automatic = false, xml2 = false) => {
     //clean up loaded file and push to list of loaded character stats
     fileData = fileData.match(STATS_REGEX).join();
 
-    if (fileData.match(/menulocation/g).length > 1) {
+    if (!xml2 && fileData.match(/menulocation/g).length > 1) {
       throw new Error(`ERROR: more than 1 occurrence of 'menulocation' found in ${item}`);
     }
 
     let charname = "";
     if (useXMLFormatOnly) {
       const herostatArray = fileData.toString().replace(/\r\n/g, "\n").split("\n");
-      charname = (herostatArray.find(function (line) { return line.includes(" name ="); })).split("=")[1].slice(1, -2);
+      charname = (herostatArray.filter(line => line.match(/^\s*name\s=/gi))[0]).split("=")[1].slice(1, -2);
     } else {
       const herostatJSON = JSON.parse(fileData.replace(`"stats": `, ``));
       charname = herostatJSON.name;

--- a/mua/xml/Bishop.xml
+++ b/mua/xml/Bishop.xml
@@ -25,11 +25,7 @@
       Multipart {
       health = 0 ;
       hideskin = gun_left ;
-      }
-
-      Multipart {
-      health = 0 ;
-      hideskin = gun_right ;
+      hideskin2 = gun_right ;
       }
 
       talent {

--- a/mua/xml/Black Panther.xml
+++ b/mua/xml/Black Panther.xml
@@ -25,11 +25,7 @@
       Multipart {
       health = 0 ;
       hideskin = dagger_l_segment ;
-      }
-
-      Multipart {
-      health = 0 ;
-      hideskin = dagger_r_segment ;
+      hideskin2 = dagger_r_segment ;
       }
 
       talent {

--- a/mua/xml/Black Widow.xml
+++ b/mua/xml/Black Widow.xml
@@ -24,10 +24,7 @@
    team = hero ;
       Multipart {
       hideskin = 20102_Mgun_segment ;
-      }
-
-      Multipart {
-      hideskin = 20102_pistol_segment ;
+      hideskin2 = 20102_pistol_segment ;
       }
 
       Multipart {

--- a/mua/xml/Blade.xml
+++ b/mua/xml/Blade.xml
@@ -25,23 +25,14 @@
       Multipart {
       health = 0 ;
       hideskin = 0101_sword_back_segment ;
-      }
-
-      Multipart {
-      health = 0 ;
-      hideskin = 0101_gun_segment ;
-      }
-
-      Multipart {
-      health = 0 ;
-      nonmenuonly = true ;
-      showskin = 0101_sword_back_segment ;
+      hideskin2 = 0101_gun_segment ;
       }
 
       Multipart {
       health = 0 ;
       hideskin = 0101_sword_segment ;
       nonmenuonly = true ;
+      showskin = 0101_sword_back_segment ;
       }
 
       talent {

--- a/mua/xml/Deadpool.xml
+++ b/mua/xml/Deadpool.xml
@@ -25,33 +25,20 @@
       Multipart {
       health = 0 ;
       hideskin = sword_l_back ;
-      }
-
-      Multipart {
-      health = 0 ;
-      hideskin = sword_r_hand ;
+      hideskin2 = sword_r_hand ;
       }
 
       Multipart {
       health = 0 ;
       hideskin = sword_l_hand_reverse ;
-      }
-
-      Multipart {
-      health = 0 ;
-      hideskin = guns ;
-      }
-
-      Multipart {
-      health = 0 ;
-      nonmenuonly = true ;
-      showskin = sword_l_back ;
+      hideskin2 = guns ;
       }
 
       Multipart {
       health = 0 ;
       hideskin = sword_l_hand ;
       nonmenuonly = true ;
+      showskin = sword_l_back ;
       }
 
       talent {

--- a/mua/xml/Elektra.xml
+++ b/mua/xml/Elektra.xml
@@ -25,33 +25,13 @@
       Multipart {
       health = 0 ;
       hideskin = 1201_sai_left_segment ;
-      }
-
-      Multipart {
-      health = 0 ;
-      hideskin = 1201_sai_right_segment ;
+      hideskin2 = 1201_sai_right_segment ;
       }
 
       Multipart {
       health = 0 ;
       hideskin = 1201_star_left_segment ;
-      }
-
-      Multipart {
-      health = 0 ;
-      hideskin = 1201_star_right_segment ;
-      }
-
-      Multipart {
-      health = 0 ;
-      menuonly = true ;
-      showskin = 1201_sai_left_segment ;
-      }
-
-      Multipart {
-      health = 0 ;
-      menuonly = true ;
-      showskin = 1201_sai_right_segment ;
+      hideskin2 = 1201_star_right_segment ;
       }
 
       talent {
@@ -67,6 +47,13 @@
       talent {
       level = 1 ;
       name = melee_moves ;
+      }
+
+      Multipart {
+      health = 0 ;
+      menuonly = true ;
+      showskin = 1201_sai_left_segment ;
+      showskin2 = 1201_sai_right_segment ;
       }
 
    }

--- a/mua/xml/Nick Fury.xml
+++ b/mua/xml/Nick Fury.xml
@@ -25,11 +25,7 @@
       Multipart {
       health = 0 ;
       hideskin = gun_left_segment ;
-      }
-
-      Multipart {
-      health = 0 ;
-      hideskin = gun_right_segment ;
+      hideskin2 = gun_right_segment ;
       }
 
       talent {

--- a/mua/xml/Nightcrawler.xml
+++ b/mua/xml/Nightcrawler.xml
@@ -40,24 +40,6 @@
       showskin = sword_Back_segment ;
       }
 
-      Multipart {
-      health = 0 ;
-      nonmenuonly = true ;
-      showskin = sword_Back_segment ;
-      }
-
-      Multipart {
-      health = 0 ;
-      hideskin = sword_L_segment ;
-      nonmenuonly = true ;
-      }
-
-      Multipart {
-      health = 0 ;
-      hideskin = sword_R_segment ;
-      nonmenuonly = true ;
-      }
-
       talent {
       level = 1 ;
       name = night_power1 ;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openheroselect",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "openheroselect",
-      "version": "4.6.1",
+      "version": "4.6.2",
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "dotenv": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openheroselect",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "description": "Open Source HeroSelect for Marvel Ultimate Alliance (2006)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
OpenHeroSelect: Fixed a bug with menulocations. Now only uses the check with MUA. Also used a better code to find the internal name, using regex. Now works with herostats with removed indent as well.

mua/xml: Combined multiparts (segment hiding) for MUA herostats. This should reduce limit issues. It seems to be backward-compatible.

workflows\build-release.yml: Used fallback, as recommended by WyriHaximus.