### PR TITLE
Linux 64-bit Support

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -48,15 +48,42 @@ jobs:
         echo "newtag=${{ env.newtag_string }}" >> $GITHUB_OUTPUT
 
   build-release:
-    name: Build and Release
-    runs-on: windows-latest
+    name: Build and Release ${{ matrix.os }}-${{ matrix.architecture }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest]
+        architecture: [x86, x64]
+        include:
+          - os: windows-latest
+            architecture: x86
+            is-linux: false
+          - os: windows-latest
+            architecture: x64
+            is-linux: false
+          - os: ubuntu-latest
+            architecture: x64
+            is-linux: true
+
     permissions:
       contents: write
     needs: check-tag
     if: ${{ needs.check-tag.outputs.newbuild == 'true' }}
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4.1.1
+
+    - name: Set up NASM
+      if: ${{ matrix.architecture == 'x86' && ! matrix.is-linux }}
+      uses: ilammy/setup-nasm@v1.5.1
+    - name: Setup scoop
+      if: ${{ matrix.architecture == 'x86' && ! matrix.is-linux }}
+      uses: MinoruSekine/setup-scoop@v3
+    - name: Install patch
+      if: ${{ matrix.architecture == 'x86' && ! matrix.is-linux }}
+      run: scoop install patch
+
     - name: Setup Node.js
       uses: actions/setup-node@v4.0.2
       with:
@@ -65,59 +92,24 @@ jobs:
       uses: actions/setup-python@v5.1.0
       with:
         python-version-file: '.python-version'
+        architecture: ${{ matrix.architecture }}
     - name: Install npm modules
       run: npm ci
     - name: Install pip modules
       run: npm run pipsetup
-    - name: Build release artifact
-      run: npm run distpackage
+
+    - name: Build release artifact ${{ matrix.architecture }}
+      if: ${{ ! matrix.is-linux }}
+      run: npm run distpackage-${{ matrix.architecture }}
+    - name: Build release artifact linux
+      if: ${{ matrix.is-linux }}
+      run: npm run distpackagelinux-${{ matrix.architecture }}
+
     - name: Create release
       uses: softprops/action-gh-release@v2.0.4
       with: 
         token: "${{ secrets.GITHUB_TOKEN }}"
         tag_name: ${{ needs.check-tag.outputs.newtag }}
-        make_latest: true
+        prerelease: true
         generate_release_notes: true
-        files: |
-          dist/OpenHeroSelect.7z
-
-  build-release-32:
-    name: Build and Release 32-bit
-    runs-on: windows-latest
-    permissions:
-      contents: write
-    needs: 
-      - check-tag
-      - build-release
-    if: ${{ needs.check-tag.outputs.newbuild == 'true' }}
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4.1.1
-    - name: Set up NASM
-      uses: ilammy/setup-nasm@v1.5.1
-    - name: Setup scoop
-      uses: MinoruSekine/setup-scoop@v3
-    - name: Install patch
-      run: scoop install patch
-    - name: Setup Node.js
-      uses: actions/setup-node@v4.0.2
-      with:
-        node-version-file: '.nvmrc'
-    - name: Setup Python
-      uses: actions/setup-python@v5.1.0
-      with:
-        python-version-file: '.python-version'
-        architecture: 'x86'
-    - name: Install npm modules
-      run: npm ci
-    - name: Install pip modules
-      run: npm run pipsetup
-    - name: Build release artifact
-      run: npm run distpackage32
-    - name: Add file to release
-      uses: softprops/action-gh-release@v2.0.4
-      with: 
-        token: "${{ secrets.GITHUB_TOKEN }}"
-        tag_name: ${{ needs.check-tag.outputs.newtag }}
-        files: |
-          dist/OpenHeroSelect-32.7z
+        files: dist/*

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -110,6 +110,6 @@ jobs:
       with: 
         token: "${{ secrets.GITHUB_TOKEN }}"
         tag_name: ${{ needs.check-tag.outputs.newtag }}
-        prerelease: true
+        make_latest: true
         generate_release_notes: true
         files: dist/*

--- a/js_source/openheroselect.js
+++ b/js_source/openheroselect.js
@@ -824,11 +824,11 @@ function compileRavenFormats(data, filename, ext) {
   fs.writeFileSync(dPath, data);
   //generate xmlb file
   const child = cspawn.sync(
-    path.resolve("json2xmlb.exe"),
+    "./json2xmlb",
     [dPath, cPath],
     {}
   );
-  if (child.stderr.length !== 0) {
+  if (child.stderr && child.stderr.length !== 0) {
     throw new Error(`${dPath}:\n${child.stderr.toString("utf8").split("\n").slice(-3).join("\n")}`);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openheroselect",
-  "version": "4.9.2",
+  "version": "4.9.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "openheroselect",
-      "version": "4.9.2",
+      "version": "4.9.3",
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "dotenv": "^16.4.5",
@@ -23,7 +23,6 @@
       "devDependencies": {
         "@eslint/js": "^9.0.0",
         "@yao-pkg/pkg": "^5.11.5",
-        "7zip-bin": "^5.2.0",
         "eslint": "^9.0.0",
         "globals": "^15.0.0",
         "node-7z": "^3.0.0",
@@ -609,12 +608,6 @@
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
-    },
-    "node_modules/7zip-bin": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
-      "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
-      "dev": true
     },
     "node_modules/acorn": {
       "version": "8.11.3",
@@ -3288,12 +3281,6 @@
           }
         }
       }
-    },
-    "7zip-bin": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
-      "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
-      "dev": true
     },
     "acorn": {
       "version": "8.11.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openheroselect",
-  "version": "4.9.2",
+  "version": "4.9.3",
   "description": "Open Source HeroSelect for Marvel Ultimate Alliance (2006)",
   "main": "index.js",
   "scripts": {
@@ -8,14 +8,18 @@
     "envsetup": "node ./_build.js -e",
     "clean": "npm i && npm run envsetup && node ./_build.js -c",
     "fullclean": "npm i && npm run envsetup && node ./_build.js -f",
-    "build": "npm run envsetup && node ./_build.js",
-    "build32": "npm run envsetup && node ./_build.js --compat32",
-    "distpackage": "npm run fullclean && npm run build && node ./_build.js -p",
-    "distpackage32": "npm run fullclean && npm run build32 && node ./_build.js -p --compat32",
-    "buildohs": "npm run envsetup && node ./_build.js -t ohs",
-    "buildohs32": "npm run envsetup && node ./_build.js -t ohs --compat32",
-    "buildjson2xmlb": "node ./_build.js -t json2xmlb",
-    "buildjson2xmlb32": "node ./_build.js -t json2xmlb --compat32",
+    "build": "npm run envsetup && node ./_build.js -a win-x64",
+    "build32": "npm run envsetup && node ./_build.js -a win-x86",
+    "buildlinux": "npm run envsetup && node ./_build.js -a linux-x64",
+    "distpackage-x64": "npm run fullclean && npm run build && node ./_build.js -p",
+    "distpackage-x86": "npm run fullclean && npm run build32 && node ./_build.js -p 32",
+    "distpackagelinux-x64": "npm run fullclean && npm run buildlinux && node ./_build.js -p linux-64",
+    "buildohs": "npm run envsetup && node ./_build.js -t ohs -a win-x64",
+    "buildohs32": "npm run envsetup && node ./_build.js -t ohs -a win-x86",
+    "buildohslinux": "npm run envsetup && node ./_build.js -t ohs -a linux-x64",
+    "buildjson2xmlb": "node ./_build.js -t json2xmlb -a win-x64",
+    "buildjson2xmlb32": "node ./_build.js -t json2xmlb -a win-x86",
+    "buildjson2xmlblinux": "node ./_build.js -t json2xmlb -a linux-x64",
     "buildcopyfiles": "node ./_build.js -t copyfiles"
   },
   "bin": {
@@ -36,7 +40,6 @@
   "devDependencies": {
     "@eslint/js": "^9.0.0",
     "@yao-pkg/pkg": "^5.11.5",
-    "7zip-bin": "^5.2.0",
     "eslint": "^9.0.0",
     "globals": "^15.0.0",
     "node-7z": "^3.0.0",


### PR DESCRIPTION
- Changed Workflow to use matrix + add Linux 64 bit build
- Added support for Linux in build and changed communication between commands and build slightly (workflow included - esp. distpackage commands)
- Changed json2xmlb exe reference in cspawn to use actual relative path instead of expanding to relative path (`./json2xmlb` works crossplatform, while expanding the file path would end up with something like `D:\OHS\json2xmlb`, with or without `.exe` suffix, which doesn't work on every platform)
- Improved stderr check of cspawn, as it seems to behave differently on Linux
- Changed from 7zip-bin to use 7zip from environment (PATH) which works in workflows at least (7zip-bin seems to be Windows only - note: only used for distpackage commands)