### PR TITLE
Changed Herostat Dialogue for Console Users

### DIFF
--- a/js_source/openheroselect.js
+++ b/js_source/openheroselect.js
@@ -300,7 +300,7 @@ const main = async (automatic = false, xml2 = false) => {
       const GIP_MESSAGE = {
         MO2: `an MO2 mod folder`,
         Direct: `your installation of ${xml2 ? XML2_NAME : MUA_NAME}`,
-        Console: `your extracted console herostat`
+        Console: `a folder with a 'data' folder inside`
       };
 
       // Ask about the installation path. Each platform has a unique message.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openheroselect",
-  "version": "4.9.3",
+  "version": "4.9.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "openheroselect",
-      "version": "4.9.3",
+      "version": "4.9.4",
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "dotenv": "^16.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openheroselect",
-  "version": "4.9.3",
+  "version": "4.9.4",
   "description": "Open Source HeroSelect for Marvel Ultimate Alliance (2006)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The message was unclear previously, as it sounded like it wants you to paste the path to the herostat directly. Which would've resulted in a 'data' folder not found error.