### PR TITLE
Updated Herostats (MUA)

### DIFF
--- a/mua/xml/Elektra.xml
+++ b/mua/xml/Elektra.xml
@@ -24,9 +24,9 @@
    team = hero ;
       Multipart {
       health = 0 ;
-      nonmenuonly = true ;
       hideskin = 1201_sai_left_segment ;
       hideskin2 = 1201_sai_right_segment ;
+      nonmenuonly = true ;
       }
 
       Multipart {

--- a/mua/xml/Hulk.xml
+++ b/mua/xml/Hulk.xml
@@ -6,6 +6,7 @@
    characteranims = 170_Hulk ;
    characteranimsclass = humanoid_large ;
    charactername = Hulk ;
+   gen_charge_color = 0.2 0.8 0.2 1 ;
    ignoreboundsscaling = true ;
    level = 1 ;
    menulocation = 19 ;
@@ -34,6 +35,11 @@
       talent {
       level = 1 ;
       name = healing_factor ;
+      }
+
+      talent {
+      level = 1 ;
+      name = hulk_rage ;
       }
 
       talent {


### PR DESCRIPTION
- Added Hulk Rage, which was in the vanilla files, but disabled (enables green rage meter and hidden rage talent)
- Fixed Elektra's modified skin segment entry (must be alphabetical) - Yes, it took me 2 years to figure it out (only 2 reports about that in two years)

Note: I didn't add a version change, because I saw that there is an experimental Mac version going on as well, and this is just a minor change to the herostats only.